### PR TITLE
chore: update to WASI 0.2.2

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -2,16 +2,16 @@
 <ul>
 <li>Imports:
 <ul>
-<li>interface <a href="#wasi_io_error_0_2_1"><code>wasi:io/error@0.2.1</code></a></li>
-<li>interface <a href="#wasi_io_poll_0_2_1"><code>wasi:io/poll@0.2.1</code></a></li>
-<li>interface <a href="#wasi_io_streams_0_2_1"><code>wasi:io/streams@0.2.1</code></a></li>
+<li>interface <a href="#wasi_io_error_0_2_2"><code>wasi:io/error@0.2.2</code></a></li>
+<li>interface <a href="#wasi_io_poll_0_2_2"><code>wasi:io/poll@0.2.2</code></a></li>
+<li>interface <a href="#wasi_io_streams_0_2_2"><code>wasi:io/streams@0.2.2</code></a></li>
 <li>interface <a href="#wasi_blobstore_types_0_2_0_draft"><code>wasi:blobstore/types@0.2.0-draft</code></a></li>
 <li>interface <a href="#wasi_blobstore_container_0_2_0_draft"><code>wasi:blobstore/container@0.2.0-draft</code></a></li>
 <li>interface <a href="#wasi_blobstore_blobstore_0_2_0_draft"><code>wasi:blobstore/blobstore@0.2.0-draft</code></a></li>
 </ul>
 </li>
 </ul>
-<h2><a id="wasi_io_error_0_2_1"></a>Import interface wasi:io/error@0.2.1</h2>
+<h2><a id="wasi_io_error_0_2_2"></a>Import interface wasi:io/error@0.2.2</h2>
 <hr />
 <h3>Types</h3>
 <h4><a id="error"></a><code>resource error</code></h4>
@@ -44,7 +44,7 @@ hazard.</p>
 <ul>
 <li><a id="method_error_to_debug_string.0"></a> <code>string</code></li>
 </ul>
-<h2><a id="wasi_io_poll_0_2_1"></a>Import interface wasi:io/poll@0.2.1</h2>
+<h2><a id="wasi_io_poll_0_2_2"></a>Import interface wasi:io/poll@0.2.2</h2>
 <p>A poll API intended to let users wait for I/O events on multiple handles
 at once.</p>
 <hr />
@@ -97,7 +97,7 @@ being ready for I/O.</p>
 <ul>
 <li><a id="poll.0"></a> list&lt;<code>u32</code>&gt;</li>
 </ul>
-<h2><a id="wasi_io_streams_0_2_1"></a>Import interface wasi:io/streams@0.2.1</h2>
+<h2><a id="wasi_io_streams_0_2_2"></a>Import interface wasi:io/streams@0.2.2</h2>
 <p>WASI I/O is an I/O abstraction API which is currently focused on providing
 stream types.</p>
 <p>In the future, the component model is expected to add built-in stream types;
@@ -118,6 +118,8 @@ when it does, they are expected to subsume this API.</p>
 <p><a id="stream_error.last_operation_failed"></a><code>last-operation-failed</code>: own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</p>
 <p>The last operation (a write or flush) failed before completion.
 <p>More information is available in the <a href="#error"><code>error</code></a> payload.</p>
+<p>After this, the stream will be closed. All future operations return
+<a href="#stream_error.closed"><code>stream-error::closed</code></a>.</p>
 </li>
 <li>
 <p><a id="stream_error.closed"></a><code>closed</code></p>

--- a/wit/container.wit
+++ b/wit/container.wit
@@ -1,6 +1,6 @@
 // a Container is a collection of objects
 interface container {
-  use wasi:io/streams@0.2.1.{
+  use wasi:io/streams@0.2.2.{
     input-stream,
     output-stream,
   };

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,4 +1,4 @@
 [io]
-url = "https://github.com/WebAssembly/wasi-io/archive/v0.2.1.tar.gz"
-sha256 = "2a74bd811adc46b5a0f19827ddbde89870e52b17615f4d0873f06fd977250caf"
-sha512 = "94624f00c66e66203592cee820f80b1ba91ecdb71f682c154f25eaf71f8d8954197dcb64503bc21e72ed5e812af7eae876df47b7eb727b02db3a74a7ce0aefca"
+url = "https://github.com/WebAssembly/wasi-io/archive/v0.2.2.tar.gz"
+sha256 = "6d8dbfaaaa685167c1829616dc7265f5f3cb776845879555612d56544f6d9bfc"
+sha512 = "52219562c4183503169cd2947b8164e1c96974500a5adf15bbf382c5992a10a626cc89c3b319204aeda6698ce59cbca2c42f98f7fde296aa77b9db4b41154dbe"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,1 +1,1 @@
-io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.1.tar.gz"
+io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.2.tar.gz"

--- a/wit/deps/io/error.wit
+++ b/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 interface error {

--- a/wit/deps/io/poll.wit
+++ b/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -18,6 +18,9 @@ interface streams {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        ///
+        /// After this, the stream will be closed. All future operations return
+        /// `stream-error::closed`.
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
@@ -205,6 +208,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.

--- a/wit/deps/io/world.wit
+++ b/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.1;
+package wasi:io@0.2.2;
 
 @since(version = 0.2.0)
 world imports {

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,6 +1,6 @@
 // Types used by blobstore
 interface types {
-  use wasi:io/streams@0.2.1.{input-stream, output-stream};
+  use wasi:io/streams@0.2.2.{input-stream, output-stream};
 
   // name of a container, a collection of objects.
   // The container name may be any valid UTF-8 string.


### PR DESCRIPTION
Note, that the interface version in the WIT is purposefully *not* changed - doing so (e.g. using `0.2.0-draft.1`) means that hosts that would want to support both versions would now need to duplicate *all* binding implementations and deal with duplicate I/O package dependencies.

There's no reason for this complexity, however, because the host may choose any version of I/O package for implementation, e.g. component interface version depending on `wasi:io/streams@0.2.2` can successfully import host interface version depending on `wasi:io/streams@0.2.0` (see an example of this working in https://github.com/wasmCloud/wasmCloud/pull/3312 if interested)